### PR TITLE
remove `Install java-1.8.0-openjdk-devel for jps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ tree](https://github.com/reallyenglish/freebsd-ports/tree/10_3_re/sysutils/logst
 
 # Requirements
 
-None
+The role requires `jps` installed and the binary must be in `$PATH`. For
+example, installing JDK is not enough in CentOS; install
+`java-1.8.0-openjdk-devel`.
 
 # Role Variables
 

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -5,13 +5,6 @@
     name: "{{ logstash_package_name }}"
     state: present
 
-- name: Install java-1.8.0-openjdk-devel for jps
-  # TODO install java-1.8.0-openjdk-devel by default in ansible-role-java and
-  # remove this task
-  yum:
-    name: java-1.8.0-openjdk-devel
-    state: present
-
 # package logstash 5.1.1 installs logstash-plugin with permission 0775
 - name: Make logstash-plugin executable
   file:


### PR DESCRIPTION
`ansible-role-java` 1.2.0 now installs the `-devel` package by default.

fixes #15 